### PR TITLE
feat: enhance UI with dark mode and lazy-loaded blogs

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,7 +14,6 @@ import { HeaderComponent } from './header/header.component';
 import { FooterComponent } from './footer/footer.component';
 import { AboutmeComponent } from './aboutme/aboutme.component';
 import { AppComponent } from './app.component';
-import { PostsComponent } from './posts/posts.component';
 import { ContactmeComponent } from './contactme/contactme.component';
 import { MarkdownModule } from 'ngx-markdown';
 import { ArticleComponent } from './article/article.component';
@@ -26,7 +25,6 @@ import { ArticleComponent } from './article/article.component';
     HeaderComponent,
     FooterComponent,
     AboutmeComponent,
-    PostsComponent,
     ContactmeComponent,
     ArticleComponent,
   ],

--- a/src/app/header/header.component.css
+++ b/src/app/header/header.component.css
@@ -1,0 +1,31 @@
+.navbar {
+  background: linear-gradient(90deg, var(--dkblue), var(--plum));
+  color: var(--white);
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+.brand {
+  font-family: var(--sans);
+  font-size: 1.5rem;
+  text-decoration: none;
+  color: var(--white);
+}
+
+.navbar a {
+  color: var(--white);
+  text-decoration: none;
+}
+
+.navbar a:hover {
+  color: var(--magenta);
+}
+
+.spacer {
+  flex: 1 1 auto;
+}
+
+.resume-button {
+  margin-right: 1rem;
+}

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,27 +1,21 @@
 <section id="navbar">
-  <nav>
-    <ul class="horizontal-navbar-list">
-      <li>
-        <a href="/"> <span class="fa-solid fa-atom"></span>Anshuman Kumar</a>
-      </li>
-      <li><a href="/blogs">Blogs</a></li>
-      <li><a href="/aboutme">About</a></li>
-      <li><a href="/contactme">Contact</a></li>
-      <li>
-        <a href="https://www.linkedin.com/in/anshumankumarcs/">
-          <span class="fa-brands fa-linkedin-in" aria-hidden="true"></span>
-          <span class="sr-only">LinkedIn</span>
-        </a>
-      </li>
-      <li>
-        <a href="https://github.com/anshumankmr">
-          <span class="fa-brands fa-github" aria-hidden="true"></span>
-          <span class="sr-only">Github</span>
-        </a>
-      </li>
-      <li>
-        <a href="../../assets/AnshumanKumarResumeDecember2024.pdf" class="button">Resume</a>
-      </li>
-    </ul>
-  </nav>
+  <mat-toolbar class="navbar">
+    <a routerLink="/" class="brand">
+      <span class="fa-solid fa-atom"></span> Anshuman Kumar
+    </a>
+    <span class="spacer"></span>
+    <a mat-button routerLink="/blogs">Blogs</a>
+    <a mat-button routerLink="/aboutme">About</a>
+    <a mat-button routerLink="/contactme">Contact</a>
+    <a mat-icon-button href="https://www.linkedin.com/in/anshumankumarcs/" aria-label="LinkedIn">
+      <span class="fa-brands fa-linkedin-in" aria-hidden="true"></span>
+    </a>
+    <a mat-icon-button href="https://github.com/anshumankmr" aria-label="Github">
+      <span class="fa-brands fa-github" aria-hidden="true"></span>
+    </a>
+    <a mat-raised-button color="accent" href="../../assets/AnshumanKumarResumeDecember2024.pdf" class="resume-button">Resume</a>
+    <button mat-icon-button (click)="toggleTheme()" [attr.aria-label]="isDark ? 'Switch to light mode' : 'Switch to dark mode'">
+      <mat-icon>{{ isDark ? 'light_mode' : 'dark_mode' }}</mat-icon>
+    </button>
+  </mat-toolbar>
 </section>

--- a/src/app/header/header.component.spec.ts
+++ b/src/app/header/header.component.spec.ts
@@ -1,4 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { HeaderComponent } from './header.component';
 
@@ -9,6 +13,7 @@ describe('HeaderComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [HeaderComponent],
+      imports: [MatToolbarModule, MatButtonModule, MatIconModule, RouterTestingModule]
     }).compileComponents();
   });
 

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -7,7 +7,19 @@ import { Component, OnInit } from '@angular/core';
 })
 export class HeaderComponent implements OnInit {
   title = "Anshuman's Blog";
+  isDark = false;
+
   constructor() {}
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    const stored = localStorage.getItem('theme');
+    this.isDark = stored ? stored === 'dark' : false;
+    document.body.classList.toggle('light-mode', !this.isDark);
+  }
+
+  toggleTheme(): void {
+    this.isDark = !this.isDark;
+    document.body.classList.toggle('light-mode', !this.isDark);
+    localStorage.setItem('theme', this.isDark ? 'dark' : 'light');
+  }
 }

--- a/src/app/modules/material/routing/routes.ts
+++ b/src/app/modules/material/routing/routes.ts
@@ -1,14 +1,17 @@
 import { Routes } from '@angular/router';
 
 import { AboutmeComponent } from '../../../aboutme/aboutme.component';
-import { PostsComponent } from 'src/app/posts/posts.component';
 import { ContactmeComponent } from 'src/app/contactme/contactme.component';
 import { ArticleComponent } from 'src/app/article/article.component';
 
 export const routes: Routes = [
   { path: '', component: AboutmeComponent },
   { path: 'aboutme', component: AboutmeComponent },
-  { path: 'blogs', component: PostsComponent },
+  {
+    path: 'blogs',
+    loadChildren: () =>
+      import('../../../posts/posts.module').then((m) => m.PostsModule),
+  },
   { path: 'contactme', component: ContactmeComponent },
   { path: 'article/:time/:slug', component: ArticleComponent },
   { path: '**', redirectTo: '/', pathMatch: 'full' },

--- a/src/app/posts/posts-routing.module.ts
+++ b/src/app/posts/posts-routing.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { PostsComponent } from './posts.component';
+
+const routes: Routes = [{ path: '', component: PostsComponent }];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class PostsRoutingModule {}

--- a/src/app/posts/posts.component.html
+++ b/src/app/posts/posts.component.html
@@ -1,5 +1,5 @@
 <div class="blog-component" *ngIf="this.loading">
-  <mat-card *ngFor="let blog of blogs">
+  <mat-card *ngFor="let blog of displayedBlogs">
     <mat-card-header>
       <mat-card-title class="card-header-text" (click)="redirectTo(blog)"><h3>{{ blog.attributes.Title }}</h3></mat-card-title>
       <mat-card-subtitle><b>Published On</b>: {{ blog.attributes.date }}</mat-card-subtitle>

--- a/src/app/posts/posts.component.spec.ts
+++ b/src/app/posts/posts.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { PostsComponent } from './posts.component';
 
@@ -9,6 +11,7 @@ describe('PostsComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [PostsComponent],
+      imports: [HttpClientTestingModule, RouterTestingModule]
     }).compileComponents();
   });
 

--- a/src/app/posts/posts.component.ts
+++ b/src/app/posts/posts.component.ts
@@ -1,19 +1,22 @@
 
-import { Component, OnInit } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
-import { CookieService } from 'ngx-cookie-service';
 
 @Component({
   selector: 'app-posts',
   templateUrl: './posts.component.html',
   styleUrls: ['./posts.component.css']
 })
-export class PostsComponent {
+export class PostsComponent implements OnInit {
   blogs: any[] = [];
-  loading: boolean = false;
-  apiError: boolean = false;
-  constructor(private http: HttpClient, private router: Router, private cookieService: CookieService) {
+  displayedBlogs: any[] = [];
+  displayCount = 5;
+  loading = false;
+  apiError = false;
+  constructor(private http: HttpClient, private router: Router) {}
+
+  ngOnInit(): void {
     this.getBlogs();
   }
   custom_sort(a:any, b: any) : number {
@@ -36,11 +39,25 @@ export class PostsComponent {
     }
   getBlogs() {
     this.http.get('https://glass-approach-204914.uc.r.appspot.com/api/blogs').subscribe((data: any) => {
-      this.blogs = data.data;
+      this.blogs = data.data.sort(this.custom_sort);
+      this.displayedBlogs = this.blogs.slice(0, this.displayCount);
       this.loading = true;
-      this.blogs = this.blogs.sort(this.custom_sort);
     }, err => {
       this.apiError = true;
     })
+  }
+
+  @HostListener('window:scroll', [])
+  onScroll(): void {
+    if ((window.innerHeight + window.scrollY) >= document.body.offsetHeight - 2) {
+      this.loadMore();
+    }
+  }
+
+  private loadMore(): void {
+    if (this.displayCount < this.blogs.length) {
+      this.displayCount += 5;
+      this.displayedBlogs = this.blogs.slice(0, this.displayCount);
+    }
   }
 }

--- a/src/app/posts/posts.module.ts
+++ b/src/app/posts/posts.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PostsComponent } from './posts.component';
+import { PostsRoutingModule } from './posts-routing.module';
+import { MaterialModule } from '../modules/material/material/material.module';
+import { MatDividerModule } from '@angular/material/divider';
+import { HttpClientModule } from '@angular/common/http';
+import { MarkdownModule } from 'ngx-markdown';
+
+@NgModule({
+  declarations: [PostsComponent],
+  imports: [
+    CommonModule,
+    PostsRoutingModule,
+    MaterialModule,
+    MatDividerModule,
+    HttpClientModule,
+    MarkdownModule
+  ]
+})
+export class PostsModule {}

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,7 @@
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="stylesheet" type="text/css" media="screen" href="styles.css" />
     <script
@@ -24,7 +25,7 @@
       rel="stylesheet"
     />
   </head>
-  <body>
+  <body class="light-mode">
     <app-root></app-root>
     <div id="wcb" class="carbonbadge wcb-d"></div>
     <script src="https://unpkg.com/website-carbon-badges@1.1.3/b.min.js" defer></script>

--- a/src/styles.css
+++ b/src/styles.css
@@ -15,6 +15,14 @@
   --padding: 1rem;
 }
 
+body.light-mode {
+  --black: #f7f8fa;
+  --white: #171321;
+  --plum: #e0e0e0;
+  background-color: var(--black);
+  color: var(--white);
+}
+
 html {
   box-sizing: border-box;
 }
@@ -33,6 +41,7 @@ body {
   background-color: var(--black);
   font-size: var(--font-size);
   line-height: var(--line-height);
+  transition: background-color 0.3s, color 0.3s;
 }
 
 a {


### PR DESCRIPTION
## Summary
- overhaul header with Angular Material toolbar and gradient styling
- add light/dark theme toggle persisted in localStorage
- lazy load blog posts and route through a dedicated posts module

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: __webpack_require__(...).context is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689570d9317c83248a3b6ca9272ece7b